### PR TITLE
fix: Use | as separator for excluding multiple methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ You can exclude assertion methods using the `.editorconfig` file:
 
 ````
 [*.cs]
-ffa_excluded_methods=M:NUnit.Framework.Assert.Fail;M:NUnit.Framework.Assert.Fail(System.String)
+ffa_excluded_methods=M:NUnit.Framework.Assert.Fail|M:NUnit.Framework.Assert.Fail(System.String)
 ````
 
 ## Getting Started

--- a/src/AwesomeAssertions.Analyzers.Tests/Tips/NunitTests.cs
+++ b/src/AwesomeAssertions.Analyzers.Tests/Tips/NunitTests.cs
@@ -22,6 +22,20 @@ public class NunitTests
         );
     }
 
+    [TestMethod]
+    [Implemented]
+    public void SupportExcludingMultipleMethods()
+    {
+        var source = GenerateCode.Nunit3Assertion("bool actual", "Assert.IsTrue(actual);Assert.IsFalse(actual);");
+        DiagnosticVerifier.VerifyDiagnostic(new DiagnosticVerifierArguments()
+            .WithAllAnalyzers()
+            .WithSources(source)
+            .WithPackageReferences(PackageReference.AwesomeAssertions_latest, PackageReference.Nunit_3_14_0)
+            .WithAnalyzerConfigOption("ffa_excluded_methods", "M:NUnit.Framework.Assert.IsTrue(System.Boolean)|M:NUnit.Framework.Assert.IsFalse(System.Boolean)")
+            .WithExpectedDiagnostics()
+        );
+    }
+
     #region Assert.cs
 
     [DataTestMethod]

--- a/src/AwesomeAssertions.Analyzers/Tips/AssertAnalyzer.cs
+++ b/src/AwesomeAssertions.Analyzers/Tips/AssertAnalyzer.cs
@@ -119,7 +119,7 @@ public class AssertAnalyzer : DiagnosticAnalyzer
         public bool IsNUnitAvailable => _nunitAssertionExceptionSymbol is not null;
         public bool IsXUnitAvailable => _xunitAssertSymbol is not null;
 
-        private static readonly char[] SymbolsSeparators = [';'];
+        private static readonly char[] SymbolsSeparators = ['|'];
 
         private bool IsMethodExcluded(AnalyzerOptions options, IInvocationOperation operation)
         {


### PR DESCRIPTION
See #36 