### PR TITLE
Exclude xunit skip* methods which have no AA equivalent

### DIFF
--- a/src/AwesomeAssertions.Analyzers.TestUtils/PackageReference.cs
+++ b/src/AwesomeAssertions.Analyzers.TestUtils/PackageReference.cs
@@ -21,6 +21,7 @@ public class PackageReference
     public static PackageReference AwesomeAssertions_latest { get; } = new("AwesomeAssertions", "9.0.0", "lib/netstandard2.0/");
     public static PackageReference MSTestTestFramework_3_1_1 { get; } = new("MSTest.TestFramework", "3.1.1", "lib/netstandard2.0/");
     public static PackageReference XunitAssert_2_5_1 { get; } = new("xunit.assert", "2.5.1", "lib/netstandard1.1/");
+    public static PackageReference Xunit3Assert_3_0_0 { get; } = new("xunit.v3.assert", "3.0.0", "lib/netstandard2.0/");
     public static PackageReference Nunit_3_14_0 { get; } = new("NUnit", "3.14.0", "lib/netstandard2.0/");
     public static PackageReference Nunit_4_0_1 { get; } = new("NUnit", "4.0.1", "lib/net6.0/");
 

--- a/src/AwesomeAssertions.Analyzers.Tests/Tips/Xunit3Tests.cs
+++ b/src/AwesomeAssertions.Analyzers.Tests/Tips/Xunit3Tests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using AwesomeAssertions.Analyzers.TestUtils;
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace AwesomeAssertions.Analyzers.Tests.Tips;
+
+[TestClass]
+public sealed class Xunit3Tests
+{
+    [TestMethod]
+    [DataRow("string reason", "Assert.Skip(reason);")]
+    [DataRow("bool condition, string reason", "Assert.SkipWhen(condition, reason);")]
+    [DataRow("bool condition, string reason", "Assert.SkipUnless(condition, reason);")]
+    [Implemented]
+    public void SkipMethod_NoDiagnostic(string methodArguments, string assertion)
+        => VerifyCSharpNoDiagnostic(methodArguments, assertion);
+
+    private void VerifyCSharpNoDiagnostic(string methodArguments, string assertion)
+    {
+        var source = GenerateCode.XunitAssertion(methodArguments, assertion);
+        DiagnosticVerifier.VerifyDiagnostic(new DiagnosticVerifierArguments()
+            .WithAllAnalyzers()
+            .WithSources(source)
+            .WithPackageReferences(PackageReference.AwesomeAssertions_latest, PackageReference.Xunit3Assert_3_0_0)
+            .WithExpectedDiagnostics()
+        );
+    }
+}

--- a/src/AwesomeAssertions.Analyzers/Tips/AssertAnalyzer.cs
+++ b/src/AwesomeAssertions.Analyzers/Tips/AssertAnalyzer.cs
@@ -151,8 +151,12 @@ public class AssertAnalyzer : DiagnosticAnalyzer
         public void AnalyzeXunitInvocation(OperationAnalysisContext context)
         {
             var op = (IInvocationOperation)context.Operation;
+
             if (op.TargetMethod.ContainingType.EqualsSymbol(_xunitAssertSymbol) && !IsMethodExcluded(context.Options, op))
             {
+                if (op.TargetMethod.Name is "Skip" or "SkipWhen" or "SkipUnless")
+                    return;
+
                 context.ReportDiagnostic(Diagnostic.Create(XunitRule, op.Syntax.GetLocation()));
             }
         }


### PR DESCRIPTION
Fixed #36 