### PR TITLE
Fix benchmark dependencies

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
     contents: write
@@ -26,6 +27,7 @@ jobs:
 
       - name: Store benchmark result
         uses: benchmark-action/github-action-benchmark@v1.20.7
+        if: ${{ github.event_name == 'push' }}
         with:
           name: AwesomeAssertions.Analyzers Benchmark
           tool: 'benchmarkdotnet'

--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,5 @@ __pycache__/
 /tools
 
 coverage.cobertura.xml
+
+BenchmarkDotNet.Artifacts/

--- a/src/AwesomeAssertions.Analyzers.BenchmarkTests/AwesomeAssertions.Analyzers.BenchmarkTests.csproj
+++ b/src/AwesomeAssertions.Analyzers.BenchmarkTests/AwesomeAssertions.Analyzers.BenchmarkTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="4.14.0" />
     <PackageReference Include="BenchmarkDotNet" />
   </ItemGroup>
 


### PR DESCRIPTION
* Benchmarkdotnet requires a recent version of Microsoft.CodeAnalysis.Workspace, but the analyzer itself must be kept at the lowest possible version